### PR TITLE
Restore SUPPORTPATH, add PROJECTSUPPORTPATH

### DIFF
--- a/src/tests/_support/bootstrap.php
+++ b/src/tests/_support/bootstrap.php
@@ -20,10 +20,11 @@ define('FCPATH',        realpath(ROOTPATH . 'public') . DIRECTORY_SEPARATOR);
 define('WRITEPATH',     realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
 define('SYSTEMPATH',    realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
 define('CIPATH',        realpath(SYSTEMPATH . '../') . DIRECTORY_SEPARATOR);
+define('SUPPORTPATH',   realpath(ROOTPATH . 'tests/_support') . DIRECTORY_SEPARATOR);
 
 // Define necessary project test path constants
-define('SUPPORTPATH',   realpath(__DIR__) . DIRECTORY_SEPARATOR);
-define('TESTPATH',      realpath(SUPPORTPATH . '../') . DIRECTORY_SEPARATOR);
+define('PROJECTSUPPORTPATH', realpath(__DIR__) . DIRECTORY_SEPARATOR);
+define('TESTPATH',           realpath(PROJECTSUPPORTPATH . '../') . DIRECTORY_SEPARATOR);
 
 // Set environment values that would otherwise stop the framework from functioning during tests.
 if (! isset($_SERVER['app.baseURL']))


### PR DESCRIPTION
The framework actually uses SUPPORTPATH to do some the behind-the-scenes mocking (like the test logger) so defining our own without supplying the mock drivers breaks functions that rely on them (like log_message()). This PR restores SUPPORTPATH to its framework reference and adds a new constant, PROJECTSUPPORTPATH for developers to use in its place.

Existing tests that reference SUPPORTPATH explicitly should be updated.