### PR TITLE
Correct whitelist path

### DIFF
--- a/src/phpunit.xml.dist
+++ b/src/phpunit.xml.dist
@@ -17,10 +17,10 @@
 
 	<filter>
 		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">./src</directory>
+			<directory suffix=".php">./app</directory>
 			<exclude>
-				<directory suffix=".php">./src/Views</directory>
-				<file>./src/Config/Routes.php</file>
+				<directory suffix=".php">./app/Views</directory>
+				<file>./app/Config/Routes.php</file>
 			</exclude>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
The PHPUnit XML had the whitelist from **ModuleTests** by mistake. This PR adds a more helpful default that points to the correct default locations. Developers will often need to modify this anyways (ideally with **phpunit.xml**, no **.dist**) so not really a breaking change but a better starting point.