### PR TITLE
Bugfix SUPPORTPATH, add docs on paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ composer.lock
 Examples of **composer.json** and **.gitignore** are located in the [examples/](examples/)
 folder if you need a starting point.
 
+### Paths
+
+A number of framework and testing path are defined as constants during the
+[bootstrap process](src/tests/_support/bootstrap.php). These default to the assumed locations
+if you have a standard directory structure and you installed the framework via Composer.
+If you move directories around or do no use Composer you will need to review these paths
+and set them appropriately.
+
+* **APPPATH**: `$paths->appDirectory`
+* **ROOTPATH**: `APPPATH . '../'`
+* **FCPATH**: `ROOTPATH . 'public/'`
+* **WRITEPATH**: `$paths->writableDirectory`
+* **SYSTEMPATH**: `$paths->systemDirectory`
+* **CIPATH**: `SYSTEMPATH . '../`
+* **SUPPORTPATH**: `CIPATH . 'tests/_support/`
+* **PROJECTSUPPORTPATH**: *bootstrap.php directory*
+* **TESTPATH**: `PROJECTSUPPORTPATH . '../`
+
 ## Updating
 
 As this repo is updated with bugfixes and improvements you will want to update your

--- a/src/tests/_support/bootstrap.php
+++ b/src/tests/_support/bootstrap.php
@@ -20,7 +20,7 @@ define('FCPATH',        realpath(ROOTPATH . 'public') . DIRECTORY_SEPARATOR);
 define('WRITEPATH',     realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
 define('SYSTEMPATH',    realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
 define('CIPATH',        realpath(SYSTEMPATH . '../') . DIRECTORY_SEPARATOR);
-define('SUPPORTPATH',   realpath(ROOTPATH . 'tests/_support') . DIRECTORY_SEPARATOR);
+define('SUPPORTPATH',   realpath(CIPATH . 'tests/_support') . DIRECTORY_SEPARATOR);
 
 // Define necessary project test path constants
 define('PROJECTSUPPORTPATH', realpath(__DIR__) . DIRECTORY_SEPARATOR);


### PR DESCRIPTION
When `SUPPORTPATH` was added back I incorrectly pointed it to the same functional directory as `PROJECTSUPPORTPATH` instead of the framework's test support directory. This redirects it and adds some docs so non-Composer users will know to make adjustments.