### PR TITLE
Specify database group on test migration

### DIFF
--- a/src/tests/_support/Database/Migrations/2019-09-02-092335_create_test_tables.php
+++ b/src/tests/_support/Database/Migrations/2019-09-02-092335_create_test_tables.php
@@ -4,6 +4,8 @@ use CodeIgniter\Database\Migration;
 
 class CreateTestTables extends Migration
 {
+	protected $DBGroup = 'tests';
+
 	public function up()
 	{
 		$fields = [


### PR DESCRIPTION
In a few scenarios running `spark migrate -all` would actually pick up the ProjectTests support path as a valid migration namespace and run the test migration(s). This PR specifies on the migration file that it is only for the `tests` DBGroup.