### PR TITLE
Bootstrap Common.php

### DIFF
--- a/src/tests/_support/bootstrap.php
+++ b/src/tests/_support/bootstrap.php
@@ -26,6 +26,15 @@ define('SUPPORTPATH',   realpath(CIPATH . 'tests/_support') . DIRECTORY_SEPARATO
 define('PROJECTSUPPORTPATH', realpath(__DIR__) . DIRECTORY_SEPARATOR);
 define('TESTPATH',           realpath(PROJECTSUPPORTPATH . '../') . DIRECTORY_SEPARATOR);
 
+// Let's see if an app/Common.php file exists
+if (file_exists(APPPATH . 'Common.php'))
+{
+	require_once APPPATH . 'Common.php';
+}
+
+// Require system/Common.php
+require_once SYSTEMPATH . 'Common.php';
+
 // Set environment values that would otherwise stop the framework from functioning during tests.
 if (! isset($_SERVER['app.baseURL']))
 {


### PR DESCRIPTION
The current bootstrap process does not load **Common.php** which can cause testing to fail when relying on functions defined there. This PR adds that early on to make sure all functions are defined before launch, mimicking the framework's priority of App > System.